### PR TITLE
fix: create user function

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -78,7 +78,7 @@ export function handleOrderCreated(
   order.inputAfterFee = calcInputAfterFee(decodedOrder);
   order.save();
 
-  createUser(decodedOrder.recipient);
+  createUser(decodedOrder.creator);
   createTokenEntity(decodedOrder.inputToken);
   createTokenEntity(decodedOrder.outputToken);
   updateTotalTokens(


### PR DESCRIPTION
This PR fixes a bug during `createOrder` function. Which affected the execution of orders with different creator and receiver address.

Instead of the creator address, the executor address was passed in the `createUser` function. 

Affected order: https://polygonscan.com/tx/0xf6c61aada6f561dea9f670226cce2c79c6aec66f95623f0cdc2ff0bb3c917c55

